### PR TITLE
#20 refactor Job Run system

### DIFF
--- a/integrations/api/src/main/kotlin/me/snoty/integration/common/wiring/flow/Flow.kt
+++ b/integrations/api/src/main/kotlin/me/snoty/integration/common/wiring/flow/Flow.kt
@@ -2,4 +2,5 @@ package me.snoty.integration.common.wiring.flow
 
 
 const val FLOW_COLLECTION_NAME = "flows"
+const val FLOW_EXECUTION_COLLECTION_NAME = "$FLOW_COLLECTION_NAME.execution"
 const val NODE_COLLECTION_NAME = "nodes"

--- a/integrations/api/src/main/kotlin/me/snoty/integration/common/wiring/flow/FlowExecution.kt
+++ b/integrations/api/src/main/kotlin/me/snoty/integration/common/wiring/flow/FlowExecution.kt
@@ -1,0 +1,19 @@
+package me.snoty.integration.common.wiring.flow
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+import me.snoty.backend.integration.config.flow.NodeId
+
+@Serializable
+data class FlowExecution(
+	val jobId: String,
+	val flowId: NodeId,
+	val startDate: Instant,
+	val status: FlowExecutionStatus?,
+)
+
+enum class FlowExecutionStatus {
+	RUNNING,
+	SUCCESS,
+	FAILED,
+}

--- a/src/main/kotlin/me/snoty/backend/database/mongo/MongoExtensions.kt
+++ b/src/main/kotlin/me/snoty/backend/database/mongo/MongoExtensions.kt
@@ -1,6 +1,10 @@
 package me.snoty.backend.database.mongo
 
 import me.snoty.integration.common.wiring.node.NodeDescriptor
+import kotlin.reflect.KProperty
 
 val NodeDescriptor.mongoCollectionPrefix: String
 	get() = "$subsystem.$type"
+
+val KProperty<*>.mongoField
+	get() = "\$$name"

--- a/src/main/kotlin/me/snoty/backend/featureflags/FeatureFlag.kt
+++ b/src/main/kotlin/me/snoty/backend/featureflags/FeatureFlag.kt
@@ -24,6 +24,15 @@ class FeatureFlagBoolean(
 	}
 }
 
+class FeatureFlagLong(
+	name: String,
+	defaultValue: Long
+) : FeatureFlag<Long>(name, defaultValue) {
+	override val getter: Client.(Long?) -> Long = { defaultValue ->
+		this.getIntegerValue(name, null)?.toLong() ?: defaultValue!!
+	}
+}
+
 open class EnumFeatureFlag<E : Enum<E>>(
 	name: String,
 	defaultValue: E,

--- a/src/main/kotlin/me/snoty/backend/featureflags/FeatureFlags.kt
+++ b/src/main/kotlin/me/snoty/backend/featureflags/FeatureFlags.kt
@@ -4,6 +4,7 @@ import dev.openfeature.sdk.Client
 import me.snoty.backend.config.Config
 import org.koin.core.annotation.Single
 import org.slf4j.event.Level
+import kotlin.time.Duration.Companion.days
 
 @Suppress("PropertyName")
 @Single
@@ -38,6 +39,8 @@ class FeatureFlags(private val config: Config, private val client: Client) {
 	val flow_logFlow = FeatureFlagBoolean("flow.logFlow", false)
 	val flow_traceConfig = FeatureFlagBoolean("flow.traceConfig", false)
 	val flow_traceInput = FeatureFlagBoolean("flow.traceInput", false)
+
+	val flow_expirationSeconds = FeatureFlagLong("flow.expirationSeconds", 7.days.inWholeSeconds)
 
 	fun <T> get(flag: FeatureFlag<T>): T = flag.getValue(client)
 }

--- a/src/main/kotlin/me/snoty/backend/integration/flow/logging/FlowLogService.kt
+++ b/src/main/kotlin/me/snoty/backend/integration/flow/logging/FlowLogService.kt
@@ -1,42 +1,87 @@
 package me.snoty.backend.integration.flow.logging
 
-import com.mongodb.client.model.Filters
-import com.mongodb.client.model.Updates
+import com.mongodb.client.model.*
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
-import kotlinx.coroutines.flow.firstOrNull
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.flow.toList
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import me.snoty.backend.database.mongo.upsertOne
+import me.snoty.backend.featureflags.FeatureFlags
 import me.snoty.backend.integration.config.flow.NodeId
 import me.snoty.integration.common.wiring.flow.FLOW_COLLECTION_NAME
 import me.snoty.integration.common.wiring.flow.NodeLogEntry
 import org.bson.codecs.pojo.annotations.BsonId
 import org.koin.core.annotation.Single
+import java.util.concurrent.TimeUnit
 
 interface FlowLogService {
-	suspend fun record(flowId: NodeId, entry: NodeLogEntry)
+	suspend fun record(jobId: String, flowId: NodeId, entry: NodeLogEntry)
 
 	suspend fun retrieve(flowId: NodeId): List<NodeLogEntry>
 }
 
 internal data class FlowLogs(
 	@BsonId
-	val _id: NodeId,
-	val logs: List<NodeLogEntry>
+	/**
+	 * The execution / job ID. Every flow can have multiple executions.
+	 */
+	val _id: String,
+	val creationDate: Instant,
+	val flowId: NodeId,
+	val logs: List<NodeLogEntry>,
 )
 
 @Single
-class MongoFlowLogService(mongoDB: MongoDatabase) : FlowLogService {
+class MongoFlowLogService(mongoDB: MongoDatabase, featureFlags: FeatureFlags) : FlowLogService {
+	private val logger = KotlinLogging.logger {}
 	private val collection = mongoDB.getCollection<FlowLogs>("$FLOW_COLLECTION_NAME.log")
 
-	override suspend fun record(flowId: NodeId, entry: NodeLogEntry) {
+	init {
+		@OptIn(DelicateCoroutinesApi::class) // the indexes are non-critical and should just *eventually* be created
+		GlobalScope.launch(Dispatchers.IO) {
+			val expirationIndex = FlowLogs::creationDate.name
+
+			collection.createIndexes(
+				listOf(
+					IndexModel(Filters.eq(FlowLogs::flowId.name, 1)),
+					IndexModel(
+						Filters.eq(FlowLogs::creationDate.name, 1),
+						IndexOptions()
+							.name(expirationIndex)
+							.expireAfter(featureFlags.get(featureFlags.flow_expirationSeconds), TimeUnit.SECONDS)
+					),
+				),
+			).retryWhen { cause, attempt ->
+				if (attempt > 3) {
+					logger.error(cause) { "Failed to create indexes on ${collection.namespace.fullName}" }
+					return@retryWhen false
+				}
+
+				logger.debug { "Dropping index $expirationIndex on ${collection.namespace.fullName} because the expiration likely changed" }
+				collection.dropIndex(expirationIndex)
+
+				true
+			}.collect()
+		}
+	}
+
+	override suspend fun record(jobId: String, flowId: NodeId, entry: NodeLogEntry) {
 		collection.upsertOne(
-			Filters.eq(FlowLogs::_id.name, flowId),
-			Updates.push(FlowLogs::logs.name, entry)
+			Filters.eq(FlowLogs::_id.name, jobId),
+			Updates.combine(
+				Updates.push(FlowLogs::logs.name, entry),
+				Updates.setOnInsert(FlowLogs::flowId.name, flowId),
+				Updates.setOnInsert(FlowLogs::creationDate.name, Clock.System.now()),
+			)
 		)
 	}
 
 	override suspend fun retrieve(flowId: NodeId): List<NodeLogEntry> =
-		collection.find(Filters.eq(FlowLogs::_id.name, flowId))
-			.firstOrNull()
-			?.logs
-			?: emptyList()
+		collection.find(Filters.eq(FlowLogs::flowId.name, flowId))
+			.toList()
+			.flatMap { it.logs }
 }

--- a/src/main/kotlin/me/snoty/backend/integration/flow/logging/FlowLogService.kt
+++ b/src/main/kotlin/me/snoty/backend/integration/flow/logging/FlowLogService.kt
@@ -3,25 +3,29 @@ package me.snoty.backend.integration.flow.logging
 import com.mongodb.client.model.*
 import com.mongodb.kotlin.client.coroutine.MongoDatabase
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.retryWhen
-import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import me.snoty.backend.database.mongo.upsertOne
+import me.snoty.backend.database.mongo.*
 import me.snoty.backend.featureflags.FeatureFlags
 import me.snoty.backend.integration.config.flow.NodeId
-import me.snoty.integration.common.wiring.flow.FLOW_COLLECTION_NAME
-import me.snoty.integration.common.wiring.flow.NodeLogEntry
+import me.snoty.backend.integration.flow.MongoWorkflow
+import me.snoty.integration.common.wiring.flow.*
 import org.bson.codecs.pojo.annotations.BsonId
 import org.koin.core.annotation.Single
+import java.util.*
 import java.util.concurrent.TimeUnit
 
 interface FlowLogService {
 	suspend fun record(jobId: String, flowId: NodeId, entry: NodeLogEntry)
+	suspend fun setExecutionStatus(jobId: String, status: FlowExecutionStatus)
 
 	suspend fun retrieve(flowId: NodeId): List<NodeLogEntry>
+	fun query(userId: UUID): Flow<FlowExecution>
 }
 
 internal data class FlowLogs(
@@ -30,15 +34,16 @@ internal data class FlowLogs(
 	 * The execution / job ID. Every flow can have multiple executions.
 	 */
 	val _id: String,
-	val creationDate: Instant,
 	val flowId: NodeId,
+	val creationDate: Instant,
+	val status: FlowExecutionStatus? = null,
 	val logs: List<NodeLogEntry>,
 )
 
 @Single
 class MongoFlowLogService(mongoDB: MongoDatabase, featureFlags: FeatureFlags) : FlowLogService {
 	private val logger = KotlinLogging.logger {}
-	private val collection = mongoDB.getCollection<FlowLogs>("$FLOW_COLLECTION_NAME.log")
+	private val collection = mongoDB.getCollection<FlowLogs>(FLOW_EXECUTION_COLLECTION_NAME)
 
 	init {
 		@OptIn(DelicateCoroutinesApi::class) // the indexes are non-critical and should just *eventually* be created
@@ -69,6 +74,13 @@ class MongoFlowLogService(mongoDB: MongoDatabase, featureFlags: FeatureFlags) : 
 		}
 	}
 
+	override suspend fun setExecutionStatus(jobId: String, status: FlowExecutionStatus) {
+		collection.updateOne(
+			Filters.eq(FlowLogs::_id.name, jobId),
+			Updates.set(FlowLogs::status.name, status),
+		)
+	}
+
 	override suspend fun record(jobId: String, flowId: NodeId, entry: NodeLogEntry) {
 		collection.upsertOne(
 			Filters.eq(FlowLogs::_id.name, jobId),
@@ -76,6 +88,7 @@ class MongoFlowLogService(mongoDB: MongoDatabase, featureFlags: FeatureFlags) : 
 				Updates.push(FlowLogs::logs.name, entry),
 				Updates.setOnInsert(FlowLogs::flowId.name, flowId),
 				Updates.setOnInsert(FlowLogs::creationDate.name, Clock.System.now()),
+				Updates.setOnInsert(FlowLogs::status.name, FlowExecutionStatus.RUNNING),
 			)
 		)
 	}
@@ -84,4 +97,45 @@ class MongoFlowLogService(mongoDB: MongoDatabase, featureFlags: FeatureFlags) : 
 		collection.find(Filters.eq(FlowLogs::flowId.name, flowId))
 			.toList()
 			.flatMap { it.logs }
+
+	override fun query(userId: UUID): Flow<FlowExecution> {
+		val flow = "flow"
+
+		data class MongoFlowExecution(
+			val jobId: String,
+			@BsonId
+			val flowId: NodeId,
+			val status: FlowExecutionStatus,
+			val startDate: Instant,
+		) {
+			fun toFlowExecution() = FlowExecution(
+				jobId = jobId,
+				flowId = flowId,
+				startDate = startDate,
+				status = status,
+			)
+		}
+
+		return collection.aggregate<MongoFlowExecution>(
+			Aggregates.sort(Sorts.descending(FlowLogs::creationDate.name)),
+			Aggregates.group(
+				FlowLogs::flowId.mongoField,
+				Accumulators.first(MongoFlowExecution::jobId.name, FlowLogs::_id.mongoField),
+				Accumulators.first(MongoFlowExecution::flowId.name, FlowLogs::flowId.mongoField),
+				Accumulators.first(MongoFlowExecution::status.name, FlowLogs::status.mongoField),
+				Accumulators.first(MongoFlowExecution::startDate.name, FlowLogs::creationDate.mongoField),
+			),
+			Aggregates.lookup(
+				/* from = */ FLOW_COLLECTION_NAME,
+				// _id as the group makes the flowId be the _id
+				/* localField = */ FlowLogs::_id.name,
+				/* foreignField = */ MongoWorkflow::_id.name,
+				/* as = */ flow,
+			),
+			Aggregates.match(Filters.elemMatch(flow, Filters.eq(MongoWorkflow::userId.name, userId))),
+			Aggregations.project(
+				Projections.exclude(flow),
+			),
+		).map { it.toFlowExecution() }
+	}
 }

--- a/src/main/kotlin/me/snoty/backend/scheduling/impl/jobrunr/node/JobRunrFlowJobHandler.kt
+++ b/src/main/kotlin/me/snoty/backend/scheduling/impl/jobrunr/node/JobRunrFlowJobHandler.kt
@@ -1,8 +1,10 @@
 package me.snoty.backend.scheduling.impl.jobrunr.node
 
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.slf4j.MDCContext
 import me.snoty.backend.integration.flow.logging.FlowLogService
 import me.snoty.backend.integration.flow.logging.NodeLogAppender
+import me.snoty.backend.observability.JOB_ID
 import me.snoty.backend.scheduling.JobRequestHandler
 import me.snoty.integration.common.wiring.data.impl.SimpleIntermediateData
 import me.snoty.integration.common.wiring.flow.FlowRunner
@@ -10,6 +12,7 @@ import me.snoty.integration.common.wiring.flow.FlowService
 import org.jobrunr.jobs.context.JobRunrDashboardLogger
 import org.koin.core.annotation.Single
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import ch.qos.logback.classic.Logger as LogbackLogger
 
 @Single
@@ -30,7 +33,9 @@ class JobRunrFlowJobHandler(
 		val jobContext = jobContext()
 		val logger = JobRunrDashboardLogger(this.rootLogger)
 
-		runBlocking {
+		MDC.put(JOB_ID.key, jobContext.jobId.toString())
+
+		runBlocking(MDCContext()) {
 			val flow = flowService.getWithNodes(jobRequest.flowId) ?: let {
 				logger.error("Flow not found: {}", jobRequest.flowId)
 				return@runBlocking

--- a/src/main/kotlin/me/snoty/backend/server/resources/wiring/FlowResource.kt
+++ b/src/main/kotlin/me/snoty/backend/server/resources/wiring/FlowResource.kt
@@ -16,6 +16,7 @@ import me.snoty.integration.common.wiring.flow.FlowService
 
 fun Routing.flowResource() {
 	val flowService: FlowService = get()
+	val flowLogService: FlowLogService = get()
 
 	post {
 		val user = call.getUser()
@@ -35,6 +36,14 @@ fun Routing.flowResource() {
 		val result = flows.toList()
 
 		call.respond(result)
+	}
+
+	get("list/executions") {
+		val user = call.getUser()
+		val executions = flowLogService.query(user.id)
+			.toList()
+
+		call.respond(executions)
 	}
 
 	get("{id}") {
@@ -66,7 +75,6 @@ fun Routing.flowResource() {
 		call.respond(HttpStatusCode.NoContent)
 	}
 
-	val flowLogService = get<FlowLogService>()
 	get("{id}/logs") {
 		val user = call.getUser()
 

--- a/src/test/kotlin/me/snoty/backend/integration/flow/FlowRunnerImplTest.kt
+++ b/src/test/kotlin/me/snoty/backend/integration/flow/FlowRunnerImplTest.kt
@@ -56,7 +56,7 @@ class FlowRunnerImplTest {
 	private val otel = createOpenTelemetry()
 	private val flagsProvider = testFeatureFlags()
 	private val tracing = FlowTracing(json = json, openTelemetry = otel.openTelemetry, featureFlags = flagsProvider.flags)
-	private val runner = FlowRunnerImpl(nodeRegistry, flagsProvider.flags, IntermediateDataMapperRegistry, tracing).apply {
+	private val runner = FlowRunnerImpl(nodeRegistry, flagsProvider.flags, IntermediateDataMapperRegistry, tracing, TestFlowLogService()).apply {
 		json = this@FlowRunnerImplTest.json
 	}
 	private val testLogService = TestFlowLogService()

--- a/src/test/kotlin/me/snoty/backend/test/TestFlowLogService.kt
+++ b/src/test/kotlin/me/snoty/backend/test/TestFlowLogService.kt
@@ -1,8 +1,12 @@
 package me.snoty.backend.test
 
+import kotlinx.coroutines.flow.Flow
 import me.snoty.backend.integration.config.flow.NodeId
 import me.snoty.backend.integration.flow.logging.FlowLogService
+import me.snoty.integration.common.wiring.flow.FlowExecution
+import me.snoty.integration.common.wiring.flow.FlowExecutionStatus
 import me.snoty.integration.common.wiring.flow.NodeLogEntry
+import java.util.*
 
 class TestFlowLogService : FlowLogService {
 	private val logs = mutableMapOf<NodeId, MutableList<NodeLogEntry>>()
@@ -13,4 +17,10 @@ class TestFlowLogService : FlowLogService {
 
 	override suspend fun retrieve(flowId: NodeId): List<NodeLogEntry>
 		= logs[flowId] ?: emptyList()
+
+	override suspend fun setExecutionStatus(jobId: String, status: FlowExecutionStatus) {
+		// NOOP
+	}
+
+	override fun query(userId: UUID): Flow<FlowExecution> = throw NotImplementedError()
 }

--- a/src/test/kotlin/me/snoty/backend/test/TestFlowLogService.kt
+++ b/src/test/kotlin/me/snoty/backend/test/TestFlowLogService.kt
@@ -7,10 +7,10 @@ import me.snoty.integration.common.wiring.flow.NodeLogEntry
 class TestFlowLogService : FlowLogService {
 	private val logs = mutableMapOf<NodeId, MutableList<NodeLogEntry>>()
 
-	override suspend fun record(rootNode: NodeId, entry: NodeLogEntry) {
-		logs.getOrPut(rootNode) { mutableListOf() }.add(entry)
+	override suspend fun record(jobId: String, flowId: NodeId, entry: NodeLogEntry) {
+		logs.getOrPut(flowId) { mutableListOf() }.add(entry)
 	}
 
-	override suspend fun retrieve(rootNode: NodeId): List<NodeLogEntry>
-		= logs[rootNode] ?: emptyList()
+	override suspend fun retrieve(flowId: NodeId): List<NodeLogEntry>
+		= logs[flowId] ?: emptyList()
 }


### PR DESCRIPTION
This change allows us to set a TTL and prevents accumulating thousands of logs.
In addition, we now store the current execution status, to be displayed in the UI.

Closes #20